### PR TITLE
Improved random positions reading if specified

### DIFF
--- a/Avcorr.cpp
+++ b/Avcorr.cpp
@@ -68,7 +68,8 @@ int Npix(vector<double> &Nav_circ, vector<double> &Nav_pix, int N, double R, dou
 
 
 
-int Results_onemodel_oneradius(string model, int nnsize, vector<double> &Nav_circ, vector<double> &Nav_pix, vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn) //calculating moments, reducing, correcting
+int Results_onemodel_oneradius(string model, int nnsize, vector<double> &Nav_circ, vector<double> &Nav_pix,
+vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, int &nrand) //calculating moments, reducing, correcting
 {
 	int msg=0;
     vector<double> x,y,z; //for angular: x,y=ra,dec
@@ -128,10 +129,10 @@ int Results_onemodel_oneradius(string model, int nnsize, vector<double> &Nav_cir
         
     }
     cout<<"Calculating moments: "<<endl;
-	if(VERSION=="angular"){CIC_angular(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn);}
-	if(VERSION=="BOX"){CIC_BOX(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn);}
-	if(VERSION=="BOX_ellipses"){CIC_BOX_ellipses(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn);}
-	if(VERSION=="LC_ellipses"){CIC_LC_ellipses(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn);}
+	if(VERSION=="angular"){CIC_angular(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn,nrand);}
+	if(VERSION=="BOX"){CIC_BOX(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn,nrand);}
+	if(VERSION=="BOX_ellipses"){CIC_BOX_ellipses(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn,nrand);}
+	if(VERSION=="LC_ellipses"){CIC_LC_ellipses(pix,moments_output,model,npix,nnsize,Xcn,Ycn,Zcn,nrand);}
     
 	return msg;
 }
@@ -164,6 +165,7 @@ int main(int argc, char *argv[])
 	}
 	
     int model_no,nnR=0,nnallax=0;
+	int nrand;
 	double progress;
 	string fnav; //file for optimization in pixelizing
     if(VERSION=="angular" or VERSION=="BOX"){iimax=nR*nmodels;}
@@ -181,7 +183,7 @@ int main(int argc, char *argv[])
 	else {fnav="Optimal_pix_BOX.txt";}
 
 	Fread<double>(fnav,{&Nav_circ,&Nav_pix},{0,1}); //reading the data
-	Read_randoms(Xcn,Ycn,Zcn,""); //reading randoms based on option(s)
+	Read_randoms(Xcn,Ycn,Zcn,"",nrand); //reading randoms based on option(s)
 
     for(int i=0;i<iimax;++i) //computation for all moments and radii
     {
@@ -192,8 +194,8 @@ int main(int argc, char *argv[])
 
         if(i%comm_size!=rank){continue;} //only current process
 		cout<<"**********Model********** "<<model_no+1<<"/"<<Model.size()<<endl;
-		if(VERSION=="angular" or VERSION=="BOX"){dset_err=Results_onemodel_oneradius(Model[model_no],nnR,Nav_circ,Nav_pix,Xcn,Ycn,Zcn);}
-		if(VERSION=="BOX_ellipses" or VERSION=="LC_ellipses"){dset_err=Results_onemodel_oneradius(Model[model_no],nnallax,Nav_circ,Nav_pix,Xcn,Ycn,Zcn);}
+		if(VERSION=="angular" or VERSION=="BOX"){dset_err=Results_onemodel_oneradius(Model[model_no],nnR,Nav_circ,Nav_pix,Xcn,Ycn,Zcn,nrand);}
+		if(VERSION=="BOX_ellipses" or VERSION=="LC_ellipses"){dset_err=Results_onemodel_oneradius(Model[model_no],nnallax,Nav_circ,Nav_pix,Xcn,Ycn,Zcn,nrand);}
         
 		if(dset_err==1)
 		{

--- a/src/CIC.h
+++ b/src/CIC.h
@@ -8,7 +8,7 @@
 #include "Parsfnames.h"
 
 //reading randoms depending on conditions
-void Read_randoms(vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, string modelname, int specific=0);
+void Read_randoms(vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, string modelname, int &nrand, int specific=0);
 
 int CRR(string ffound,string ffoundhst,vector<double> &Xcn, string model, double val1, double val2, double val3, double val4); //number of circles/ellipses drawn
 
@@ -27,12 +27,12 @@ void Shift_zeros(vector<int> &nc, vector<int> &count);
 //checking whether count exist
 int Check_count_existence(string ffound, string ffoundhst, string output, vector<int> &nc, vector<int> &count,  double R);
 
-void CIC_angular(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnR, vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn); //collecting numbers of objects  ->calculating moments for nnR-th radius
+void CIC_angular(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnR, vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, int &nrand); //collecting numbers of objects  ->calculating moments for nnR-th radius
 
-void CIC_BOX(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnR,vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn);//collecting numbers of objects  ->calculating moments for nnR-th radius
+void CIC_BOX(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnR,vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, int &nrand);//collecting numbers of objects  ->calculating moments for nnR-th radius
 
-void CIC_BOX_ellipses(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnallax,vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn); //collecting numbers of objects  ->calculating moments for nnR-th radius
+void CIC_BOX_ellipses(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnallax,vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, int &nrand); //collecting numbers of objects  ->calculating moments for nnR-th radius
 
-void CIC_LC_ellipses(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnallax,vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn); //collecting numbers of objects  ->calculating moments for nnR-th radius
+void CIC_LC_ellipses(vector<vector<vector<double> > > &pix, string output, string model, int npix_edge, int nnallax,vector<double> &Xcn, vector<double> &Ycn, vector<double> &Zcn, int &nrand); //collecting numbers of objects  ->calculating moments for nnR-th radius
 
 #endif

--- a/src/Changes.txt
+++ b/src/Changes.txt
@@ -54,3 +54,4 @@ Changes implemented:
 22.04.2025: solved error in 2D writing, nan->-1 in Moments.cpp, improved parameter error for real_template
 05.05.2025: parameter file errors now are showing only for rank=0 (avoid duplications)
 05.06.2025: generalized inputs: datafiles do not have neccessarily be in Data/
+06.06.2025: improving random positions reading


### PR DESCRIPTION
- repaired missing option for reading globally random files in Random/ if specified, for 3D modes
- now, if Random_provided=1, reading random positions in random order to avoid counts in the same positions for the same
data file, but different scale. Random files (if specified, e.g. for complicated sky footprint) hence have to be significantly larger than:
kappa*nreals*no_fitting,
to have counts for different positions for various scales (no_fitting - number of circles/spheres/ellipsoids <depending on the mode> of given scale which can fit within the catalog).
- updated number of circles/spheres/ellipsoids considered in CRR() for Random_provided=1 option: it was number of positions in random file(s), now it is min(no_random,CR_standard), where CR_standard is previous computation: no_fitting*kappa*nreals limited by [Cmin,Cmax]